### PR TITLE
Add default admin user

### DIFF
--- a/db.php
+++ b/db.php
@@ -18,3 +18,18 @@ $pdo = new PDO($dsn, $user, $pass, $options);
 $tz = new DateTimeZone($timezone);
 $offset = (new DateTime('now', $tz))->format('P');
 $pdo->exec("SET time_zone = '$offset'");
+
+$pdo->exec('CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4');
+
+$userCount = $pdo->query('SELECT COUNT(*) FROM users')->fetchColumn();
+if ($userCount == 0) {
+    $stmt = $pdo->prepare('INSERT INTO users (username, password) VALUES (:username, :password)');
+    $stmt->execute([
+        ':username' => 'admin',
+        ':password' => password_hash('admin', PASSWORD_DEFAULT),
+    ]);
+}


### PR DESCRIPTION
## Summary
- Ensure users table exists and seed default admin/admin user on first run

## Testing
- `php -l db.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7b1d28d78832e822a835d039ed101