### PR TITLE
Notify manual behavior changes via Telegram

### DIFF
--- a/calls.php
+++ b/calls.php
@@ -79,11 +79,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $behStmt = $pdo->prepare('SELECT name FROM behaviors WHERE code = :code');
                 $behStmt->execute([':code' => $number]);
                 $behaviorName = $behStmt->fetchColumn();
-                if ($behaviorName) {
-                    $text = urlencode("Comportamiento {$behaviorName} activado en la centralita");
-                    $url = "https://api.telegram.org/bot{$telegramBotId}/sendMessage?chat_id={$telegramChatId}&text={$text}";
-                    @file_get_contents($url);
-                }
+                $behaviorLabel = $behaviorName ?: $number;
+                $text = urlencode("Comportamiento {$behaviorLabel} activado manualmente en la extensión {$extension}");
+                $url = "https://api.telegram.org/bot{$telegramBotId}/sendMessage?chat_id={$telegramChatId}&text={$text}";
+                @file_get_contents($url);
             }
         } else {
             $message = 'Both extension and comportamiento are required.';


### PR DESCRIPTION
## Summary
- send a Telegram message when a behavior change is executed manually, including the extension

## Testing
- `php -l calls.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7b99a1324832e8af1984504389791