### PR TITLE
Treat weekends as regular days in scheduling

### DIFF
--- a/schedule_utils.php
+++ b/schedule_utils.php
@@ -1,17 +1,13 @@
 <?php
 function nextWorkingDay(DateTime $date): DateTime {
     $d = clone $date;
-    do {
-        $d->modify('+1 day');
-    } while (in_array($d->format('N'), [6,7]));
+    $d->modify('+1 day');
     return $d;
 }
 
 function previousWorkingDay(DateTime $date): DateTime {
     $d = clone $date;
-    do {
-        $d->modify('-1 day');
-    } while (in_array($d->format('N'), [6,7]));
+    $d->modify('-1 day');
     return $d;
 }
 


### PR DESCRIPTION
## Summary
- Adjust scheduling utility to consider weekends the same as weekdays by removing weekend-skipping logic.

## Testing
- `php -l schedule_utils.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7cee28144832ebe307fc599bdf875