### PR TITLE
Resaltar día actual en calendarios

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -131,6 +131,23 @@ $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.
     <link rel="icon" type="image/png" href="favicon.png">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
+    <style>
+        .flatpickr-day {
+            position: relative;
+        }
+
+        .flatpickr-day.today::after {
+            content: "";
+            position: absolute;
+            top: 3px;
+            left: 3px;
+            right: 3px;
+            bottom: 3px;
+            border: 2px solid #0d6efd;
+            border-radius: 4px;
+            pointer-events: none;
+        }
+    </style>
 </head>
 
 <body>

--- a/dashboard.php
+++ b/dashboard.php
@@ -43,6 +43,20 @@ foreach ($allPeriods as $row) {
         transform: scale(1.3);
         transform-origin: top center;
     }
+    .flatpickr-day {
+        position: relative;
+    }
+    .flatpickr-day.today::after {
+        content: "";
+        position: absolute;
+        top: 3px;
+        left: 3px;
+        right: 3px;
+        bottom: 3px;
+        border: 2px solid #0d6efd;
+        border-radius: 4px;
+        pointer-events: none;
+    }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- añade un estilo específico para resaltar el día actual en los calendarios con flatpickr
- aplica el mismo resaltado tanto en el calendario de configuración como en el de resumen

## Testing
- no se realizaron pruebas (cambios de estilo)


------
https://chatgpt.com/codex/tasks/task_e_68cd4ffe0968832eaf33ff0c91baf5c4