### PR TITLE
Restore original calendar behavior indicator styling

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -134,7 +134,6 @@ $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.
     <style>
         .flatpickr-day {
             position: relative;
-            z-index: 0;
         }
 
         .flatpickr-day.today::after {
@@ -147,25 +146,6 @@ $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.
             border: 2px solid #0d6efd;
             border-radius: 4px;
             pointer-events: none;
-            z-index: 1;
-        }
-
-        .flatpickr-day.has-behavior,
-        .flatpickr-day.has-behavior:hover,
-        .flatpickr-day.has-behavior:focus {
-            color: #fff;
-            background: transparent !important;
-            border-color: transparent !important;
-        }
-
-        .flatpickr-day.has-behavior::before {
-            content: "";
-            position: absolute;
-            inset: 6px;
-            border-radius: 50%;
-            background-color: var(--behavior-color, transparent);
-            pointer-events: none;
-            z-index: -1;
         }
     </style>
 </head>
@@ -261,28 +241,21 @@ $pendingCalls = $pdo->query('SELECT sc.extension, sc.number, sc.scheduled_at, b.
             fp.calendarContainer.querySelectorAll('.flatpickr-day').forEach(function(dayElem) {
                 var date = fp.formatDate(dayElem.dateObj, 'Y-m-d');
                 var color = '';
+                var textColor = '';
                 if (selectedDates.indexOf(date) !== -1) {
                     color = currentBehaviorColor;
+                    textColor = '#fff';
                 } else {
-                    Object.keys(behaviorSchedules).some(function(code) {
+                    Object.keys(behaviorSchedules).forEach(function(code) {
                         if (behaviorSchedules[code].dates.indexOf(date) !== -1) {
                             color = behaviorColors[code];
-                            return true;
+                            textColor = '#fff';
                         }
-                        return false;
                     });
                 }
-                if (color) {
-                    dayElem.classList.add('has-behavior');
-                    dayElem.style.setProperty('--behavior-color', color);
-                    dayElem.style.color = '#fff';
-                } else {
-                    dayElem.classList.remove('has-behavior');
-                    dayElem.style.removeProperty('--behavior-color');
-                    dayElem.style.color = '';
-                }
-                dayElem.style.backgroundColor = '';
-                dayElem.style.boxShadow = '';
+                dayElem.style.backgroundColor = color;
+                dayElem.style.color = textColor;
+                dayElem.style.boxShadow = color ? 'none' : '';
             });
         }
 


### PR DESCRIPTION
## Summary
- remove the pseudo-element based indicator styling on calendar days to revert their original size
- reinstate background color highlighting for behavior days while keeping the outline that marks the current day

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68da29c2bfc0832e91e3a3110d2451cd